### PR TITLE
  CI: Add Workflow to Deploy Site to GitHub Pages

### DIFF
--- a/workflows/deploy-pages.yml
+++ b/workflows/deploy-pages.yml
@@ -1,0 +1,40 @@
+   name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ] # This will only run when a change is pushed to the main branch
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build # Make sure your build output goes to a 'dist' folder
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist' # Change this if your build folder has a different name (e.g., 'build', 'public')
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a Continuous Deployment (CD) pipeline that automatically builds and deploys our website to GitHub Pages.

The workflow will trigger on every push to the `main` branch. It performs the following steps:
1. Installs dependencies and builds the static site.
2. Uploads the build artifact.
3. Deploys the artifact to GitHub Pages.

### Prerequisite Check

For the deployment to succeed, please ensure that the repository's **Settings > Pages** configuration is set to use **"GitHub Actions"** as the deployment source.
